### PR TITLE
Adding a  config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Open-Source-PDKs-docs
+
+channels:
+- defaults
+
+dependencies:
+- python>=3.8
+- pip:
+  - -r docs/requirements.txt
+
+sphinx:
+  fail_on_warning: true


### PR DESCRIPTION
Fixes #14 

- Simple `.readthedocs.yaml` is included.

- [x] `.readthedocs.yaml` is included.